### PR TITLE
Use CSQ instead of most_severe_consequence

### DIFF
--- a/reference/rank_model_snv.ini
+++ b/reference/rank_model_snv.ini
@@ -155,7 +155,8 @@
   data_type = string
   description = Most severe consequence for this variant
   field = INFO
-  info_key = most_severe_consequence
+  csq_key = Consequence
+  info_key = CSQ
   record_rule = max
   separators = ',', ':', '|',
 
@@ -357,7 +358,7 @@
     score = 3
     priority = 1
     string = 'PASS'
-  
+
   [[dot]]
     score = 3
     priority = 2


### PR DESCRIPTION
Use CSQ instead of most_severe_consequence so the addmostsevereconsequence module in Nallo can be removed, without updating genmod with `--skip_plugins_check`. 